### PR TITLE
Fixed bug in CampaignCash::Candidate#create_from_search_results

### DIFF
--- a/lib/campaign_cash/candidate.rb
+++ b/lib/campaign_cash/candidate.rb
@@ -53,7 +53,7 @@ module CampaignCash
 		           :office => parse_office(params['candidate']['id'][0..0]),
 		           :district => parse_district(params['district']),
 		           :party => params['candidate']['party'],
-		           :committee => parse_committee(params['committee'])
+		           :committee_id => parse_committee(params['committee'])
 		  
 		end
 		

--- a/test/campaign_cash/test_candidate.rb
+++ b/test/campaign_cash/test_candidate.rb
@@ -19,13 +19,18 @@ class TestCampaignCash::TestCandidate < Test::Unit::TestCase
 				assert_equal(@result[attr], @candidate.send(attr))
 			end
 		end
+		
+		should "assign the committee_id to a stripped version of the attribute from the 'committee' key in the hash" do
+      assert_equal(Base.parse_committee(@result['committee']), @candidate.committee_id)
+    end
+    
   end
 	
 	context "Candidate search" do
 	  setup do
 		  reply = Base.invoke('2010/candidates/search', {:query => "Udall"})
-			results = reply['results']
-	    @candidates = results.map{|c| Candidate.create_from_search_results(c)}
+			@results = reply['results']
+	    @candidates = @results.map{|c| Candidate.create_from_search_results(c)}
 	  end
 	  
 	  should "return two candidate objects" do
@@ -33,6 +38,11 @@ class TestCampaignCash::TestCandidate < Test::Unit::TestCase
 	    assert_kind_of(Candidate, @candidates.first)
 	    assert_kind_of(Candidate, @candidates.last)
 	  end
+	  
+	  should "assign the committee_id to a stripped version of the attribute from the 'committee' key in the hash" do
+      assert_equal(Base.parse_committee(@results.first['committee']), @candidates.first.committee_id)
+    end    
+		
 	end
 	
 	context "New Candidates" do


### PR DESCRIPTION
All candidates were coming in with committee_id as nil. This fixes the problem.
