### PR TITLE
"chamber" param to Candidate.state_chamber made optional

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    campaign_cash (2.0.7)
+    campaign_cash (2.3)
       json
 
 GEM

--- a/lib/campaign_cash/candidate.rb
+++ b/lib/campaign_cash/candidate.rb
@@ -127,14 +127,19 @@ module CampaignCash
       results.map{|c| self.create(c)}      
     end
     
-    # Returns an array of candidates for a given state and chamber within a cycle, with an optional
-    # district parameter. For example, House candidates from New York. Defaults to the current cycle.
-    def self.state_chamber(state, chamber, district=nil, cycle=CURRENT_CYCLE, offset=nil)
-      district ? path = "#{cycle}/seats/#{state}/#{chamber}/#{district}" : path = "#{cycle}/seats/#{state}/#{chamber}"
-			reply = invoke(path,{:offset => offset})
-			results = reply['results']
+    # Returns an array of candidates for a given state within a cycle, with optional chamber and
+    # district parameters. For example, House candidates from New York. Defaults to the current cycle.
+    def self.state(state, chamber=nil, district=nil, cycle=CURRENT_CYCLE, offset=nil)
+      path = "#{cycle}/seats/#{state}"
+      if chamber
+        path += "/#{chamber}"
+        path += "/#{district}" if district
+      end
+      reply = invoke(path,{:offset => offset})
+      results = reply['results']
       results.map{|c| self.create_from_search_results(c)}      
     end
     
+    instance_eval { alias :state_chamber :state }
   end
 end

--- a/test/campaign_cash/test_candidate.rb
+++ b/test/campaign_cash/test_candidate.rb
@@ -74,12 +74,20 @@ class TestCampaignCash::TestCandidate < Test::Unit::TestCase
 	end
 		
 	context "state candidates" do
-	  setup do
-		  @candidates = Candidate.state_chamber('RI', 'house', nil, 2010)
-	  end
+	  should "return 32 total candidates from Rhode Island" do
+	    assert_equal Candidate.state('RI', nil, nil, 2010).length, 32
+    end
 	  
 	  should "return 29 House candidates from Rhode Island" do
-	    assert_equal @candidates.size, 29
+	    assert_equal Candidate.state('RI', "house", nil, 2010).length, 29
+	  end
+	  
+	  should "return 3 Senate candidates from Rhode Island" do
+	    assert_equal Candidate.state('RI', "senate", nil, 2010).length, 3
+	  end
+	  
+	  should "return 17 House candidates from District 1 of Rhode Island" do
+	    assert_equal Candidate.state('RI', "house", 1, 2010).length, 17
 	  end
 	end
 end


### PR DESCRIPTION
The chamber parameter is optional in the underlying API.

Renamed the method to `Candidate.state` to reflect this change. Kept the original as an alias. Also added tests with and without the optional `chamber` and `district` parameters.
